### PR TITLE
Add nofile limitation for dynamic_flag

### DIFF
--- a/dynamic_flag/docker-compose.yml
+++ b/dynamic_flag/docker-compose.yml
@@ -9,6 +9,10 @@ services:
     ipc: shareable
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     environment:
       - hackergame_conn_interval=${conn_interval}
       - hackergame_token_timeout=${token_timeout}


### PR DESCRIPTION
Fix dynamic_flag in some platforms like Arch Linux. By default Arch's docker is started with this systemd configuration:

```
# Having non-zero Limit*s causes performance problems due to accounting overhead
# in the kernel. We recommend using cgroups to do container-local accounting.
LimitNOFILE=infinity
LimitNPROC=infinity
LimitCORE=infinity
```

Which means 1+ billion file descriptors allowed, and this makes xinetd insane and unavailable for quite some minutes:

```
close(87662441)                         = -1 EBADF (Bad file descriptor)
close(87662442)                         = -1 EBADF (Bad file descriptor)
close(87662443)                         = -1 EBADF (Bad file descriptor)
close(87662444)                         = -1 EBADF (Bad file descriptor)
close(87662445)                         = -1 EBADF (Bad file descriptor)
close(87662446)                         = -1 EBADF (Bad file descriptor)
close(87662447)                         = -1 EBADF (Bad file descriptor)
close(87662448)                         = -1 EBADF (Bad file descriptor)
close(87662449)                         = -1 EBADF (Bad file descriptor)
close(87662450)                         = -1 EBADF (Bad file descriptor)
close(87662451)                         = -1 EBADF (Bad file descriptor)
close(87662452)                         = -1 EBADF (Bad file descriptor)
close(87662453)                         = -1 EBADF (Bad file descriptor)
close(87662454)                         = -1 EBADF (Bad file descriptor)
close(87662455)                         = -1 EBADF (Bad file descriptor)
close(87662456)                         = -1 EBADF (Bad file descriptor)
close(87662457)                         = -1 EBADF (Bad file descriptor)
close(87662458)                         = -1 EBADF (Bad file descriptor)
close(87662459)                         = -1 EBADF (Bad file descriptor)
close(87662460)                         = -1 EBADF (Bad file descriptor)
close(87662461)                         = -1 EBADF (Bad file descriptor)
close(87662462)                         = -1 EBADF (Bad file descriptor)
close(87662463)                         = -1 EBADF (Bad file descriptor)
close(87662464)                         = -1 EBADF (Bad file descriptor)
close(87662465)                         = -1 EBADF (Bad file descriptor)
close(87662466)                         = -1 EBADF (Bad file descriptor)
close(87662467)                         = -1 EBADF (Bad file descriptor)
close(87662468)                         = -1 EBADF (Bad file descriptor)
close(87662469)                         = -1 EBADF (Bad file descriptor)
close(87662470)                         = -1 EBADF (Bad file descriptor)
close(87662471^C)                         = -1 EBADF (Bad file descriptor)
```