### PR TITLE
web_netcat: implement copy with Ctrl + Shift + C

### DIFF
--- a/web_netcat/static/index.html
+++ b/web_netcat/static/index.html
@@ -25,6 +25,16 @@
         letterSpacing: 0,
         fontFamily: 'monospace',
       });
+      term.attachCustomKeyEventHandler((e) => {
+        // Ctrl + Shift + C, to prevent browser from opening devtools
+        if (e.ctrlKey && e.shiftKey && e.keyCode == 67) {
+          e.preventDefault();
+          const success = document.execCommand('copy');
+          if (!success) {
+            console.error('Failed to copy to clipboard');
+          }
+        }
+      });
       const fitAddon = new FitAddon.FitAddon();
       term.loadAddon(fitAddon);
       term.open(document.getElementById("terminal"));


### PR DESCRIPTION
By default, modern browsers might start devtools when users press Ctrl + Shift + C. This commit prevents this behavior and do the copy with execCommand.