### PR TITLE
use lxcfs to fake system resources in container

### DIFF
--- a/dynamic_flag/front.py
+++ b/dynamic_flag/front.py
@@ -34,7 +34,7 @@ challenge_network = os.environ.get("hackergame_challenge_network", "")
 # shm_exec sets /dev/shm no longer be noexec. Default = keep noexec
 shm_exec = 1 if os.environ.get("hackergame_shm_exec") == "1" else 0
 
-lxcfs_opts = '-v /var/lib/lxcfs/proc/cpuinfo:/proc/cpuinfo:rw -v /var/lib/lxcfs/proc/diskstats:/proc/diskstats:rw -v /var/lib/lxcfs/proc/meminfo:/proc/meminfo:rw -v /var/lib/lxcfs/proc/stat:/proc/stat:rw -v /var/lib/lxcfs/proc/swaps:/proc/swaps:rw -v /var/lib/lxcfs/proc/uptime:/proc/uptime:rw -v /var/lib/lxcfs/proc/slabinfo:/proc/slabinfo:rw -v /var/lib/lxcfs/sys/devices/system/cpu:/sys/devices/system/cpu:rw'
+lxcfs_opts = '-v /var/lib/lxcfs/proc/cpuinfo:/proc/cpuinfo:ro -v /var/lib/lxcfs/proc/diskstats:/proc/diskstats:ro -v /var/lib/lxcfs/proc/meminfo:/proc/meminfo:ro -v /var/lib/lxcfs/proc/stat:/proc/stat:ro -v /var/lib/lxcfs/proc/swaps:/proc/swaps:ro -v /var/lib/lxcfs/proc/uptime:/proc/uptime:ro -v /var/lib/lxcfs/proc/slabinfo:/proc/slabinfo:ro -v /var/lib/lxcfs/sys/devices/system/cpu:/sys/devices/system/cpu:ro'
 
 with open("cert.pem") as f:
     cert = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, f.read())


### PR DESCRIPTION
Currently the challenge docker can see the whole resouces (e.g., free RAM, disk space and CPU cores) of the host machine by reading `/proc`. This causes many troubles because programs may adjust their behavior based on the amount of available resouces.

For example, even if the container has a small resource limit, `java` will still set a large heap limit, and `nginx` will spawn many workers:

<img width="487" alt="95c4f6dcf3717e3ee6ae06b27970fc8" src="https://github.com/user-attachments/assets/fbe35de0-956f-4b84-a439-58bb949beb1e">

To avoid this scenario, this PR uses [lxcfs](https://github.com/lxc/lxcfs) to mock the `/proc` filesystem. The container will now see the correct resource limits, and programs like `nginx` will work fine.

![image](https://github.com/user-attachments/assets/2009c718-8f7b-4b7a-88c0-8d995daab8d4)

-----

Additional notes for this PR:

1. Need to `apt install lxcfs` on the host, which will start a systemd daemon to mount the `/var/lib/lxcfs` FUSE.
2. Apart from the existing `--cpus 1` flag, containers will be further restricted to `--cpuset-cpus {THREE_RANDOM_CPU_CORE}` so that `nproc` will return 3 in the container. It is set to 3 instead of 1 to avoid two containers on the same core interfering with each other.